### PR TITLE
06 remove getObjID  function from ACB

### DIFF
--- a/src/CAPcore/Web.py
+++ b/src/CAPcore/Web.py
@@ -145,23 +145,6 @@ def createBrowser(config=Namespace()):
     return browser
 
 
-# https://effbot.org/zone/default-values.htm#what-to-do-instead
-sentinel = object()
-
-
-def getObjID(objURL, clave='id', defaultresult=sentinel):
-    PATid = r'^.*/' + clave + r'/(?P<id>\d+)(/.*)?'
-    REid = re.match(PATid, objURL)
-
-    if REid:
-        return REid.group('id')
-
-    if defaultresult is sentinel:
-        raise ValueError(f"getObjID '{objURL}' no casa patrón '{PATid}' para clave '{clave}'")
-
-    return defaultresult
-
-
 def findObjectsWithAttributes(webContent, targetTag, targetInfo):
     result = dict()
     for k, fname, fvalue in targetInfo:

--- a/tests/utils/test_Misc.py
+++ b/tests/utils/test_Misc.py
@@ -1,34 +1,37 @@
 import unittest
 
-from  src.CAPcore.Misc import removeSuffix
+from src.CAPcore.Misc import removeSuffix
+
 
 class TestRemoveSuffix(unittest.TestCase):
     def test_badParamsBoth(self):
-        self.assertRaisesRegex(TypeError,r"^removeSuffix: one or both parameters are not a str.*",removeSuffix,None,None)
+        self.assertRaisesRegex(TypeError, r"^removeSuffix: one or both parameters are not a str.*", removeSuffix, None,
+                               None)
 
     def test_badParamsFirst(self):
-        self.assertRaisesRegex(TypeError,r"^removeSuffix: one or both parameters are not a str.*",removeSuffix,1,"aaa")
-
+        self.assertRaisesRegex(TypeError, r"^removeSuffix: one or both parameters are not a str.*", removeSuffix, 1,
+                               "aaa")
 
     def test_badParamsSecond(self):
-        self.assertRaisesRegex(TypeError,r"^removeSuffix: one or both parameters are not a str.*",removeSuffix,"aaa",(3,))
+        self.assertRaisesRegex(TypeError, r"^removeSuffix: one or both parameters are not a str.*", removeSuffix, "aaa",
+                               (3,))
 
-        self.assertRaisesRegex(TypeError,r"^removeSuffix: one or both parameters are not a str.*")
+        self.assertRaisesRegex(TypeError, r"^removeSuffix: one or both parameters are not a str.*")
 
     def test_noSuffix(self):
-        d1 = removeSuffix('a123','4')
+        d1 = removeSuffix('a123', '4')
         self.assertEqual(d1, 'a123')
 
     def test_happyPath1(self):
-        d1 = removeSuffix('a123','3')
+        d1 = removeSuffix('a123', '3')
         self.assertEqual(d1, 'a12')
 
     def test_happyPath2(self):
-        d1 = removeSuffix('a123','23')
+        d1 = removeSuffix('a123', '23')
         self.assertEqual(d1, 'a1')
 
     def test_happyPath3(self):
-        d1 = removeSuffix('a1233','3')
+        d1 = removeSuffix('a1233', '3')
         self.assertEqual(d1, 'a123')
 
 


### PR DESCRIPTION
This function shouldn't have been added in the first place so it will be returned to ACB